### PR TITLE
added github embed support to docify

### DIFF
--- a/submissions.json
+++ b/submissions.json
@@ -22,5 +22,14 @@
 			"https://medium.com/@brunopgalvao/deploying-your-first-contract-to-polkadot-in-5minutes-5cf190601b99",
 			"https://www.youtube.com/watch?v=TwT2eX58Rc8"
 		]
+	},
+	{
+		"author": "sam0x17",
+		"description": "added github embedding feature to docify at parity's request",
+		"evidence": [
+			"https://github.com/sam0x17/docify/pull/29",
+			"https://github.com/sam0x17/docify/pull/30",
+			"https://github.com/sam0x17/docify/releases/tag/v0.3.0"
+		]
 	}
 ]


### PR DESCRIPTION
polkadot address: `5ESAMx17PWX2t6roLVc1H9xLmMgLk9VCbG2J4a7VWzacuhpD`

I am ex-parity. I originally developed docify while at Parity to aid in our documentation efforts in polkadot-sdk, and docify is now used extensively within the mono-repo. Kian reached out to me to see if I could add this feature that would allow for doing git-based embeds in docify, to unblock using docify to do cross-crate embedding in crates.io/docs.rs deploys. This was a difficult feature to develop because of the limitations of the crates.io/docs.rs build environment. I paid one of my contractors ~$2.5k to do it, after a bunch of iterations.

Relevant material:
* https://github.com/sam0x17/docify/issues/14
* https://github.com/sam0x17/docify/pull/29
* https://github.com/sam0x17/docify/pull/30